### PR TITLE
Containerize orfondl

### DIFF
--- a/container/Containerfile
+++ b/container/Containerfile
@@ -1,11 +1,17 @@
 FROM docker.io/node:21-bookworm-slim
 LABEL org.opencontainers.image.authors="toughIQ@gmail.com"
 
-RUN apt update && apt upgrade -y && apt install -y git ffmpeg
+RUN apt update && apt upgrade -y && apt install -y wget unzip ffmpeg
 
-RUN git clone https://github.com/badlogic/orfondl.git \
+RUN wget https://github.com/badlogic/orfondl/archive/refs/heads/main.zip \
+    && unzip main.zip \
+    && mv orfondl-main orfondl \
     && cd orfondl \
     && npm install
+
+#RUN git clone https://github.com/badlogic/orfondl.git \
+#    && cd orfondl \
+#    && npm install
     
 RUN mkdir /download    
 

--- a/container/Containerfile
+++ b/container/Containerfile
@@ -1,0 +1,14 @@
+FROM docker.io/node:21-bookworm-slim
+LABEL org.opencontainers.image.authors="toughIQ@gmail.com"
+
+RUN apt update && apt upgrade -y && apt install -y git ffmpeg
+
+RUN git clone https://github.com/badlogic/orfondl.git \
+    && cd orfondl \
+    && npm install
+    
+RUN mkdir /download    
+
+COPY entrypoint.sh /
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/container/README.md
+++ b/container/README.md
@@ -9,6 +9,7 @@ change into `container` directory of `orfondl` project.
 ## Run orfondl container with output directory
 
 `podman run -it --rm -v /my/download/directory:/download:z docker.io/toughiq/orfondl:latest https://on.orf.at/video/14212146`
+
 where `/my/download/directory` is the path where you want your resulting videos stored and `https://on.orf.at/video/14212146` is the URL of the desired video.
 
 ## Running multiple downloads at once

--- a/container/README.md
+++ b/container/README.md
@@ -1,0 +1,13 @@
+# Containerize orfondl
+
+## Build container image
+
+change into `container` directory of `orfondl project.
+
+`podman build -t orfondl:latest .`
+
+## Run ordondl container with output directory
+
+`podman run -it --rm -v /my/download/directory:/download:z orfondl:latest https://on.orf.at/video/14212146`
+where `/my/download/directory` is the path where you want your resulting videos stored and `https://on.orf.at/video/14212146` is the URL of the desired video.
+

--- a/container/README.md
+++ b/container/README.md
@@ -14,7 +14,7 @@ where `/my/download/directory` is the path where you want your resulting videos 
 
 ## Running multiple downloads at once
 
-Currently there is no mechanism to provide a list of download URLs. But you can invoke multiple download instances at by `daemonizing` each container runtime.
+Currently there is no mechanism to provide a list of download URLs. But you can invoke multiple download instances at by `daemonizing` each container at runtime with `-d` and removing the `-it` parameter.
 
 Eg:
 

--- a/container/README.md
+++ b/container/README.md
@@ -13,10 +13,12 @@ where `/my/download/directory` is the path where you want your resulting videos 
 
 ## Running multiple downloads at once
 
-Currently there is no mechanism to provide a list of download URLs. But you can invoke multiple download instances at by `deamonizing` each container runtime.
+Currently there is no mechanism to provide a list of download URLs. But you can invoke multiple download instances at by `daemonizing` each container runtime.
 
 Eg:
+
 `podman run -d --rm -v /my/download/directory:/download:z docker.io/toughiq/orfondl:latest https://on.orf.at/video/14202586/soko-donau-zuendstoff`
+
 `podman run -d --rm -v /my/download/directory:/download:z docker.io/toughiq/orfondl:latest https://on.orf.at/video/14211599/soko-donau-schachmatt`
 
 You can check the progress via:

--- a/container/README.md
+++ b/container/README.md
@@ -4,12 +4,31 @@
 
 change into `container` directory of `orfondl` project.
 
-`podman build -t orfondl:latest .`
+`podman build -t docker.io/toughiq/orfondl:latest .`
 
 ## Run orfondl container with output directory
 
-`podman run -it --rm -v /my/download/directory:/download:z orfondl:latest https://on.orf.at/video/14212146`
+`podman run -it --rm -v /my/download/directory:/download:z docker.io/toughiq/orfondl:latest https://on.orf.at/video/14212146`
 where `/my/download/directory` is the path where you want your resulting videos stored and `https://on.orf.at/video/14212146` is the URL of the desired video.
+
+## Running multiple downloads at once
+
+Currently there is no mechanism to provide a list of download URLs. But you can invoke multiple download instances at by `deamonizing` each container runtime.
+
+Eg:
+`podman run -d --rm -v /my/download/directory:/download:z docker.io/toughiq/orfondl:latest https://on.orf.at/video/14202586/soko-donau-zuendstoff`
+`podman run -d --rm -v /my/download/directory:/download:z docker.io/toughiq/orfondl:latest https://on.orf.at/video/14211599/soko-donau-schachmatt`
+
+You can check the progress via:
+`podman ps` which shows you something like this, if the containers are still running:
+```
+CONTAINER ID  IMAGE                             COMMAND               CREATED         STATUS         PORTS       NAMES
+914f097ef51b  docker.io/toughiq/orfondl:latest  https://on.orf.at...  10 minutes ago  Up 10 minutes              crazy_mcnulty
+6562da38cf33  docker.io/toughiq/orfondl:latest  https://on.orf.at...  9 minutes ago   Up 9 minutes               stupefied_moser
+a83b809bd5c1  docker.io/toughiq/orfondl:latest  https://on.orf.at...  8 minutes ago   Up 8 minutes               adoring_haibt
+e87867a1db54  docker.io/toughiq/orfondl:latest  https://on.orf.at...  7 minutes ago   Up 7 minutes               heuristic_spence
+```
+
 
 ## Inner workings
 

--- a/container/README.md
+++ b/container/README.md
@@ -6,12 +6,12 @@ change into `container` directory of `orfondl` project.
 
 `podman build -t orfondl:latest .`
 
-## Run ordondl container with output directory
+## Run orfondl container with output directory
 
 `podman run -it --rm -v /my/download/directory:/download:z orfondl:latest https://on.orf.at/video/14212146`
 where `/my/download/directory` is the path where you want your resulting videos stored and `https://on.orf.at/video/14212146` is the URL of the desired video.
 
-## inner workings
+## Inner workings
 
 Since `output.mp4` is currently hardcoded as output filename this container does a file move and rename at the end, so the resulting video is stored with the video ID as filename within the `download` directory.
 

--- a/container/README.md
+++ b/container/README.md
@@ -11,3 +11,7 @@ change into `container` directory of `orfondl` project.
 `podman run -it --rm -v /my/download/directory:/download:z orfondl:latest https://on.orf.at/video/14212146`
 where `/my/download/directory` is the path where you want your resulting videos stored and `https://on.orf.at/video/14212146` is the URL of the desired video.
 
+## inner workings
+
+Since `output.mp4` is currently hardcoded as output filename this container does a file move and rename at the end, so the resulting video is stored with the video ID as filename within the `download` directory.
+

--- a/container/README.md
+++ b/container/README.md
@@ -2,7 +2,7 @@
 
 ## Build container image
 
-change into `container` directory of `orfondl project.
+change into `container` directory of `orfondl` project.
 
 `podman build -t orfondl:latest .`
 

--- a/container/entrypoint.sh
+++ b/container/entrypoint.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+# change into orfondl directory
+cd /orfondl
+
+# parse URL for video ID ... later used as download filename
+ID=$(echo $1 | sed 's:.*/::')
+
+# fetch stream and save to orfondl directory by default ... currently $ID isnt used since output.mp4 is hardcoded
+node index.js $1 $ID.mp4
+
+# move downloaded output.mp4 to download directory and assign video ID filename
+mv -f /orfondl/output.mp4 /download/$ID.mp4
+


### PR DESCRIPTION
created a containerized version of `orfondl` so nothing has to be installed on the running machine.

This image also mitigates the hardcoded `output.mp4` file by renaming the downloaded file to `videoID.mp4` at the end and moving it to the dedicated `/download` directory.

Currently this image is designed to be build locally. If this is fine with this project, it can for sure be published under this project with some Container Registry.